### PR TITLE
Basic UI

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,0 @@
-
-// Called when the user clicks on the browser action.
-chrome.browserAction.onClicked.addListener(function() {
-  chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
-    chrome.tabs.sendMessage(tabs[0].id, {action: 'icon_click'}, function() {})
-  })
-})

--- a/config.html
+++ b/config.html
@@ -4,9 +4,39 @@
     <meta http-equiv="Content-Type" content="text/html; charset-utf-8"/>
     <title>LinkedIncognito</title>
     <script type="text/javascript" src="config.js"></script>
+    <style type="text/css" media="screen">
+      body {
+        margin: 25px 0 0 0;
+        text-align: center;
+        min-width: 100px;
+      }
+      h1 {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        background-color: #444;
+        color: #BBB;
+        font-size: 100%;
+        margin: 0;
+      }
+      h2 {
+        background-color: #EEE;
+        color: #666;
+        font-size: 100%;
+      }
+      p {
+        margin: 0;
+      }
+      .count {
+        font-size: 1.25em;
+      }
+    </style>
   </head>
   <body>
     <h1>LinkedIncognito</h1>
     <button class="toggle">Toggle</button>
+    <h2>elements <s>redacted</s></h2>
+    <p class="count">...</p>
   </body>
 </html>

--- a/config.html
+++ b/config.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset-utf-8"/>
+    <title>LinkedIncognito</title>
+    <script type="text/javascript" src="config.js"></script>
+  </head>
+  <body>
+    <h1>LinkedIncognito</h1>
+    <button class="toggle">Toggle</button>
+  </body>
+</html>

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+const sendMessageToActiveTab = (message) => {
+  chrome.tabs.query({ active: true, currentWindow: true }, ([{ id }]) => {
+    chrome.tabs.sendMessage(id, message)
+  })
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelector('.toggle').addEventListener('click', () => {
+    sendMessageToActiveTab({ action: 'toggle' })
+  })
+})

--- a/config.js
+++ b/config.js
@@ -4,8 +4,16 @@ const sendMessageToActiveTab = (message) => {
   })
 }
 
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.action === 'state') {
+    document.querySelector('.count').firstChild.nodeValue = message.count
+  }
+})
+
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelector('.toggle').addEventListener('click', () => {
     sendMessageToActiveTab({ action: 'toggle' })
   })
+
+  sendMessageToActiveTab({ action: 'requestState' })
 })

--- a/content.js
+++ b/content.js
@@ -1,8 +1,8 @@
 let hide = true
 
 chrome.runtime.onMessage.addListener(
-  function(request) {
-    if (request.action === 'icon_click') {
+  (request) => {
+    if (request.action === 'toggle') {
       hide = !hide
       parsePage()
     }
@@ -23,7 +23,7 @@ const parsePage = () => {
   })
 }
 
-function unredactElement(element, replacementRule) {
+const unredactElement = (element, replacementRule) => {
   if (replacementRule.type === 'text') {
     element.textContent = element.getAttribute('data-linkedincognito-textcontent')
     element.removeAttribute('data-linkedincognito-textcontent')
@@ -36,7 +36,7 @@ function unredactElement(element, replacementRule) {
   }
 }
 
-function redactElement(element, replacementRule) {
+const redactElement = (element, replacementRule) => {
   if (replacementRule.type === 'text') {
     const redactedTextContent = element.getAttribute('data-linkedincognito-textcontent')
 
@@ -64,9 +64,9 @@ function redactElement(element, replacementRule) {
   }
 }
 
-function observe() {
-  // select the target node
-  var [target] = document.getElementsByTagName('body')
+const observe = () => {
+  // listen for changes on the entire document. at `document_start` time, only the root node (html) is available
+  var [target] = document.getElementsByTagName('html')
 
   // create an observer instance
   var observer = new MutationObserver(() => {
@@ -74,6 +74,7 @@ function observe() {
       parsePage()
     }
   })
+
   observer.observe(target, {
     childList: true,
     subtree: true,

--- a/content.js
+++ b/content.js
@@ -5,9 +5,20 @@ chrome.runtime.onMessage.addListener(
     if (request.action === 'toggle') {
       hide = !hide
       parsePage()
+    } else if (request.action === 'requestState') {
+      publishState()
     }
   }
 )
+
+const publishState = () => {
+  const count = document.querySelectorAll('[data-linkedincognito-element-is-redacted]').length
+  chrome.runtime.sendMessage({
+    action: 'state',
+    count,
+    hide,
+  })
+}
 
 const parsePage = () => {
   const redactions = redactionMap[document.domain]
@@ -21,6 +32,8 @@ const parsePage = () => {
       }
     }
   })
+
+  publishState()
 }
 
 const unredactElement = (element, replacementRule) => {
@@ -34,6 +47,8 @@ const unredactElement = (element, replacementRule) => {
   } else {
     throw new Error(`Unrecognized replacment rule type ${replacementRule.type}`)
   }
+
+  element.removeAttribute('data-linkedincognito-element-is-redacted')
 }
 
 const redactElement = (element, replacementRule) => {
@@ -62,6 +77,8 @@ const redactElement = (element, replacementRule) => {
   } else {
     throw new Error(`Unrecognized replacment rule type ${replacementRule.type}`)
   }
+
+  element.setAttribute('data-linkedincognito-element-is-redacted', true)
 }
 
 const observe = () => {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
     "version": "1.0",
     "short_name": "LinkedIncognito",
     "browser_action": {
-        "default_title": "LinkedIncognito"
+        "default_title": "LinkedIncognito",
+        "default_popup": "config.html"
     },
     "icons": {
         "16": "icon-16.png",
@@ -24,7 +25,7 @@
                 "redactionMap.js",
                 "content.js"
             ],
-            "run_at": "document_idle"
+            "run_at": "document_start"
         }
     ],
     "background": {

--- a/manifest.json
+++ b/manifest.json
@@ -27,10 +27,5 @@
             ],
             "run_at": "document_start"
         }
-    ],
-    "background": {
-        "scripts": [
-            "background.js"
-        ]
-    }
+    ]
 }

--- a/redactionMap.js
+++ b/redactionMap.js
@@ -1,4 +1,4 @@
-const redactionMap = {
+const redactionMap = { // eslint-disable-line
   'www.linkedin.com': [
     {
       description: 'Main candidate profile name',


### PR DESCRIPTION
 * Fix an issue where un-redacted content would momentarily appear on the page before the extension ran
* Introduce a basic popup window for controlling the state of the extension
* Remove all functions from global scope; use lambdas
* Style the ui, some.
* Indicate how many elements are redacted on the page
* Remove background.js, no longer needed