### PR TITLE
Improve UI to indicate state of extension, allow pausing

### DIFF
--- a/config.html
+++ b/config.html
@@ -31,11 +31,57 @@
       .count {
         font-size: 1.25em;
       }
+      .switch {
+        cursor: pointer;
+        position: relative;
+        display: inline-block;
+        width: 60px;
+        height: 34px;
+      }
+      .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #CCC;
+        transition: .4s;
+        border-radius: 34px;
+      }
+      .slider:before {
+        position: absolute;
+        content: "";
+        height: 26px;
+        width: 26px;
+        left: 4px;
+        bottom: 4px;
+        background-color: #FFF;
+        transition: .4s;
+        border-radius: 50%;
+      }
+      .toggle:checked + .slider {
+        background-color: #2196F3;
+      }
+      .toggle:focus + .slider {
+        box-shadow: 0 0 1px #2196F3;
+      }
+      .toggle:checked + .slider:before {
+        transform: translateX(26px);
+      }
+      .pause {
+        cursor: pointer;
+        font-size: 40px;
+      }
     </style>
   </head>
   <body>
     <h1>LinkedIncognito</h1>
-    <button class="toggle">Toggle</button>
+    <label class="switch">
+      <input type="checkbox" class="toggle" style="display:none;" checked="checked">
+      <span class="slider"></span>>
+    </label>
+    <div class="pause">||</div>
     <h2>elements <s>redacted</s></h2>
     <p class="count">...</p>
   </body>

--- a/config.js
+++ b/config.js
@@ -7,12 +7,18 @@ const sendMessageToActiveTab = (message) => {
 chrome.runtime.onMessage.addListener((message) => {
   if (message.action === 'state') {
     document.querySelector('.count').firstChild.nodeValue = message.count
+    document.querySelector('.toggle').checked = message.hide
+    document.querySelector('.pause').textContent = message.hide ? '||' : ''
   }
 })
 
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelector('.toggle').addEventListener('click', () => {
     sendMessageToActiveTab({ action: 'toggle' })
+  })
+
+  document.querySelector('.pause').addEventListener('click', () => {
+    sendMessageToActiveTab({ action: 'pause' })
   })
 
   sendMessageToActiveTab({ action: 'requestState' })

--- a/content.js
+++ b/content.js
@@ -1,4 +1,5 @@
 let hide = true
+let timeoutReference = null
 
 chrome.runtime.onMessage.addListener(
   (request) => {
@@ -7,9 +8,24 @@ chrome.runtime.onMessage.addListener(
       parsePage()
     } else if (request.action === 'requestState') {
       publishState()
+    } else if (request.action === 'pause') {
+      pauseRedaction()
     }
   }
 )
+
+const pauseRedaction = () => {
+  if (!timeoutReference) {
+    hide = false
+    parsePage()
+    timeoutReference = setTimeout(() => {
+      hide = true
+      parsePage()
+      clearTimeout(timeoutReference)
+      timeoutReference = null
+    }, 10 * 60 * 1000) // pause for 10 minutes
+  }
+}
 
 const publishState = () => {
   const count = document.querySelectorAll('[data-linkedincognito-element-is-redacted]').length
@@ -17,6 +33,7 @@ const publishState = () => {
     action: 'state',
     count,
     hide,
+    paused : timeoutReference ? true : false,
   })
 }
 


### PR DESCRIPTION
* Add ability to pause redaction for 10 minutes
* The toggle switch now reflects the true state of the extension (indicates whether or not it is enabled)
* Toggle switch shamelessly cribbed from w3schools