### PR TITLE
Fix 21

### DIFF
--- a/content.js
+++ b/content.js
@@ -55,7 +55,8 @@ const parsePage = () => {
 
 const unredactElement = (element, replacementRule) => {
   if (replacementRule.type === 'text') {
-    element.textContent = element.getAttribute('data-linkedincognito-textcontent')
+    const [textNode] = element.childNodes
+    textNode.nodeValue = element.getAttribute('data-linkedincognito-textcontent')
     element.removeAttribute('data-linkedincognito-textcontent')
   } else if (replacementRule.type === 'attribute') {
     const attributeKey = `data-linkedincognito-${replacementRule.attribute}`
@@ -76,8 +77,10 @@ const redactElement = (element, replacementRule) => {
       element.setAttribute('data-linkedincognito-textcontent', element.textContent)
     }
 
-    if (element.textContent !== replacementRule.value) {
-      element.textContent = replacementRule.value
+    const [textNode] = element.childNodes
+
+    if (textNode.nodeValue !== replacementRule.value) {
+      textNode.nodeValue = replacementRule.value
     }
   } else if (replacementRule.type === 'attribute') {
     const attributeKey = `data-linkedincognito-${replacementRule.attribute}`

--- a/content.js
+++ b/content.js
@@ -5,6 +5,8 @@ chrome.runtime.onMessage.addListener(
   (request) => {
     if (request.action === 'toggle') {
       hide = !hide
+      clearTimeout(timeoutReference)
+      timeoutReference = null
       parsePage()
     } else if (request.action === 'requestState') {
       publishState()


### PR DESCRIPTION
* Fixes #21, we were inserting a new textnode that LinkedIn's code didn't have permission to remove. Now instead we'll just re-use their node and alter its value.
Also fixing issue where pause did not work correctly after an unpause.